### PR TITLE
Synchroniser avec la version en prod sur Validata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 1.0.0 -> 1.0.1
+
+Changements pour intégration au SCDL :
+  - ajout des fichiers `CONTEXT.md`, `SEE_ALSO.md` et `CHANGELOG.md`
+  - ajout de la propriété `uri`
+  - modification du titre

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,13 @@
+Dans le but de constituer un répertoire national des Infrastructures de Recharge de Véhicules Electriques \(IRVE\), ouvert et accessible à tous, les collectivités locales porteuses d'un projet d'installation d'IRVE doivent, au fur et à mesure de la mise en service des stations, publier sur la plateforme data.gouv.fr les données statiques relatives à la localisation et aux caractéristiques techniques de ces installations selon les modalités définies dans [l'arrêté du 12 janvier 2017](https://www.legifrance.gouv.fr/jo_pdf.do?id=JORFTEXT000033860733).
+
+Etalab réalise une consolidation des jeux de données IRVE déposés sur data.gouv.fr et publiée dans le jeu de données "[Fichier consolidé des Bornes de Recharge pour Véhicules Électriques IRVE](https://www.data.gouv.fr/fr/datasets/5448d3e0c751df01f85d0572/)", se conformant au schéma IRVE.
+
+De fait, ce schéma a été élaboré par Etalab à partir des documents suivants :
+
+* **Documents de cadrage juridique**
+  * [Décret n° 2017-26 du 12 janvier 2017 relatif aux infrastructures de recharge pour véhicules électriques et portant diverses mesures de transposition de la directive 2014/94/UE du Parlement européen et du Conseil du 22 octobre 2014 sur le déploiement d’une infrastructure pour carburants alternatifs](https://www.legifrance.gouv.fr/jo_pdf.do?id=JORFTEXT000033860620)
+  * [Arrêté du 12 janvier 2017 relatif aux données concernant la localisation géographique et les caractéristiques techniques des stations et des points de recharge pour véhicules électriques](https://www.legifrance.gouv.fr/jo_pdf.do?id=JORFTEXT000033860733)
+  * [Arrêté du 12 janvier 2017 précisant les dispositions relatives aux identifiants des unités d’exploitation pour la recharge des véhicules électriques](https://www.legifrance.gouv.fr/jo_pdf.do?id=JORFTEXT000033860743)
+* **Documents de cadrage technique**
+  * [Fichier de consolidation des stations de recharge de véhicules électriques sur data.gouv.fr](https://www.data.gouv.fr/fr/datasets/fichier-exemple-stations-de-recharge-de-vehicules-electriques/)
+  * [Définition et structure des identifiants attribués par l'Association Française pour l'Itinérance de la Recharge Electrique des Véhicules \(AFIREV\)](http://www.afirev.fr/fr/informations-generales/)

--- a/SEE_ALSO.md
+++ b/SEE_ALSO.md
@@ -1,0 +1,9 @@
+La spécification du modèle de données peut être utilement complétée par les documents suivants :
+
+* [Fichier gabarit à télécharger au format xlsx](https://scdl.opendatafrance.net/docs/templates/scdl-irve.xlsx)
+* [Schéma de validation](https://github.com/etalab/schema-irve/blob/master/schema.json)
+
+Pour poser une question, commenter, faire un retour d’usage ou contribuer à l’amélioration du modèle de données, vous pouvez :
+
+* adresser un message à [validation@data.gouv.fr](mailto:validation@data.gouv.fr?subject=IRVE)
+* ouvrir un ticket sur le [dépôt Github de la mission Etalab](https://github.com/etalab/schema-irve/issues/new)

--- a/SEE_ALSO.md
+++ b/SEE_ALSO.md
@@ -1,6 +1,7 @@
 La spécification du modèle de données peut être utilement complétée par les documents suivants :
 
 * [Fichier gabarit à télécharger au format xlsx](https://scdl.opendatafrance.net/docs/templates/scdl-irve.xlsx)
+* [Fichier gabarit à télécharger au format csv](https://www.data.gouv.fr/fr/datasets/fichier-exemple-stations-de-recharge-de-vehicules-electriques/) (proposé par Etalab)
 * [Schéma de validation](https://github.com/etalab/schema-irve/blob/master/schema.json)
 
 Pour poser une question, commenter, faire un retour d’usage ou contribuer à l’amélioration du modèle de données, vous pouvez :

--- a/schema.json
+++ b/schema.json
@@ -1,14 +1,16 @@
 {
-    "title": "Schéma IRVE",
+    "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
+    "title": "Infrastructures de recharge de véhicules électriques",
     "description": "Spécification du fichier d'échange relatif aux données concernant la localisation géographique et les caractéristiques techniques des stations et des points de recharge pour véhicules électriques",
     "author": "Alexandre Bulté pour Etalab",
     "contact": "validation@data.gouv.fr",
-    "contributor": "Charles Nepote",
-    "version": "1.0.0",
+    "contributor": "Charles Nepote, Pierre Dittgen, Johan Richer",
+    "version": "1.0.1",
     "created": "2018-06-29",
-    "updated": "2018-09-10",
+    "updated": "2019-05-06",
     "homepage": "https://github.com/etalab/schema-irve",
-    "example": "https://github.com/etalab/schema-irve/blob/master/exemple-valide.csv",
+    "uri": "https://github.com/etalab/schema-irve/raw/v1.0.1/schema.json",
+    "example": "https://github.com/etalab/schema-irve/raw/v1.0.1/exemple-valide.csv",
     "fields": [
         {
             "name": "n_amenageur",
@@ -112,7 +114,7 @@
         },
         {
             "name": "puiss_max",
-            "description": "La puissance maximale délivrée à chaque point de recharge, exprimée en kW, en fonction du contrat d'abonnement de puissance de la station et du type de connecteur.",
+            "description": "La puissance maximale délivrée à chaque point de recharge, exprimée en kW, en fonction du contrat d'abonnement de puissance de la station et du type de connecteur",
             "example": "22.00",
             "type": "number",
             "constraints": {
@@ -139,7 +141,7 @@
         },
         {
             "name": "accessibilité",
-            "description": "Amplitude d'ouverture de la station.",
+            "description": "Amplitude d'ouverture de la station",
             "example": "24/24 7/7 jours",
             "type": "string",
             "constraints": {


### PR DESCRIPTION
Merci pour la création de ce dépôt ! Voici une proposition pour le synchroniser avec [notre fork](https://github.com/OpenDataFrance/schema.data.gouv.fr/tree/master/irve) en vue de l'utilisation du schéma IRVE sur [go.validata.fr](https://go.validata.fr/) et dans [la documentation SCDL](http://scdl.opendatafrance.net/), si vous le souhaitez en tant que mainteneurs du schéma.

Au programme principalement :

* ajout de la propriété `uri` dans le schéma
* ajout de `CONTEXT.md` et `SEE_ALSO.md`, nécessaires à la génération de la documentation
* ajout de `CHANGELOG.md`
* utilisation du title préconisé par @loichay, pour plus d'homogénéité avec les autres schémas
* mise à jour des liens
* tag `v1.0.1`