### PR TITLE
Add acronym in title

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
     "name": "irve",
-    "title": "Infrastructures de recharge pour véhicules électriques",
+    "title": "Infrastructures de recharge pour véhicules électriques (IRVE)",
     "description": "Spécification du fichier d'échange relatif aux données concernant la localisation géographique et les caractéristiques techniques des stations et des points de recharge pour véhicules électriques",
     "countryCode": "FR",
     "homepage": "https://github.com/etalab/schema-irve",


### PR DESCRIPTION
Useful when searching in schema.data.gouv.fr for example.

Do we need a version bump for this? I don't think so.

<img width="615" alt="Capture d’écran 2022-03-08 à 09 55 14" src="https://user-images.githubusercontent.com/119625/157202756-c31dfe4d-5a2d-4bf8-b6e7-d0831aef029b.png">

