### PR TITLE
Mise à jour regex identifiants stations et pdc

### DIFF
--- a/statique/schema-statique.json
+++ b/statique/schema-statique.json
@@ -168,7 +168,7 @@
             "type": "string",
             "constraints": {
                 "required": true,
-                "pattern": "(?:(?:^|,)(^FR[A-Z0-9]{4,33}$|Non concerné))+$"
+                "pattern": "(?:(?:^|,)(^FR[A-Z0-9]{3}P[A-Z0-9]{1,30}$|Non concerné))+$"
             }
         },
         {
@@ -251,7 +251,7 @@
             "type": "string",
             "constraints": {
                 "required": true,
-                "pattern": "(?:(?:^|,)(^FR[A-Z0-9]{4,33}$|Non concerné))+$"
+                "pattern": "(?:(?:^|,)(^FR[A-Z0-9]{3}E[A-Z0-9]{1,30}$|Non concerné))+$"
             }
         },
         {


### PR DESCRIPTION
Je propose de rendre la regex plus précise pour les champs `id_pdc_itinerance` et `id_station_itinerance`.

En effet l'[afirev](https://afirev.fr/fr/informations-generales/) explique que les stations ont un "P" dans leur identifiants, tandis que les points de charge ont un "E". C'est d'ailleurs ce qui est expliqué dans la doc du schéma. Mais les regex associées autorisent actuellement de mettre un identifiant avec un "E" dans la colonne `id_station_itinerance` et certains producteurs le font.
