### PR TITLE
Détection automatique des liens morts dans le JSON et corrections associées

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,3 +42,6 @@ jobs:
     - name: Vérification du schéma dynamique et des fichiers d'exemples associés
       run: |
         frictionless validate --type schema dynamique/schema-dynamique.json
+    - name: Vérification de l'absence de liens cassés dans les schémas
+      run: |
+        elixir checks.exs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - uses: erlef/setup-beam@v1
+      with:
+        version-file: .tool-versions
+        version-type: strict
     - name: Installation Python 3.12
       uses: actions/setup-python@v5
       with:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,5 @@
+# See useful links for maintenance here:
+# https://github.com/etalab/transport-site/blob/master/.tool-versions
+
+elixir 1.16.1-otp-26
+erlang 26.2.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 # See useful links for maintenance here:
 # https://github.com/etalab/transport-site/blob/master/.tool-versions
 
-elixir 1.16.1-otp-26
-erlang 26.2.1
+elixir 1.15.5-otp-24
+erlang 24.3.4.13

--- a/checks.exs
+++ b/checks.exs
@@ -1,0 +1,41 @@
+Mix.install([
+  {:jason, "~> 1.4"},
+  {:req, "~> 0.4.8"}
+])
+
+defmodule Deadlinks do
+  # scan an Elixir structure to find links
+  def scan(x) when is_list(x) or is_map(x) do
+    x
+    |> Enum.map(&scan(&1))
+    |> List.flatten()
+    |> Enum.reject(&is_nil(&1))
+  end
+
+  def scan(x) when is_tuple(x), do: scan(x |> Tuple.to_list())
+  def scan(value = "http" <> _), do: value
+  def scan(_), do: nil
+end
+
+broken_json_links =
+  "**/*.json"
+  |> Path.wildcard()
+  |> Enum.map(fn x ->
+    x
+    |> File.read!()
+    |> Jason.decode!()
+  end)
+  |> Deadlinks.scan()
+  |> Enum.uniq()
+  |> Enum.map(fn x ->
+    Req.head!(x)
+    |> Map.take([:status])
+    |> Map.put(:url, x)
+  end)
+  |> Enum.reject(fn %{status: x} -> x == 200 end)
+
+unless broken_json_links == [] do
+  IO.puts("Some links are broken, please fix them:\n")
+  IO.puts(broken_json_links |> Enum.map(&inspect(&1)) |> Enum.join("\n"))
+  System.halt(1)
+end

--- a/dynamique/schema-dynamique.json
+++ b/dynamique/schema-dynamique.json
@@ -5,11 +5,11 @@
     "description": "Spécification du fichier d'échange relatif aux données concernant la localisation géographique et les caractéristiques techniques des stations et des points de recharge pour véhicules électriques",
     "countryCode": "FR",
     "homepage": "https://github.com/etalab/schema-irve",
-    "path": "https://github.com/etalab/schema-irve/raw/v2.2.1/schema.json",
+    "path": "https://raw.githubusercontent.com/etalab/schema-irve/v2.2.1/dynamique/schema-dynamique.json",
     "resources": [
         {
             "title": "Exemple de fichier IRVE valide",
-            "path": "https://github.com/etalab/schema-irve/raw/v2.2.1/exemple-valide-dynamique.csv"
+            "path": "https://raw.githubusercontent.com/etalab/schema-irve/v2.2.1/dynamique/exemple-valide-dynamique.csv"
         }
     ],
     "sources": [

--- a/statique/schema-statique.json
+++ b/statique/schema-statique.json
@@ -5,11 +5,11 @@
     "description": "Spécification du fichier d'échange relatif aux données concernant la localisation géographique et les caractéristiques techniques des stations et des points de recharge pour véhicules électriques",
     "countryCode": "FR",
     "homepage": "https://github.com/etalab/schema-irve",
-    "path": "https://github.com/etalab/schema-irve/raw/v2.2.1/schema.json",
+    "path": "https://raw.githubusercontent.com/etalab/schema-irve/v2.2.1/statique/schema-statique.json",
     "resources": [
         {
             "title": "Exemple de fichier IRVE valide",
-            "path": "https://github.com/etalab/schema-irve/raw/v2.2.1/exemple-valide.csv"
+            "path": "https://raw.githubusercontent.com/etalab/schema-irve/v2.2.1/statique/exemple-valide-statique.csv"
         }
     ],
     "sources": [


### PR DESCRIPTION
Cela fait plusieurs fois qu'on finit par avoir des liens cassés dans la doc, et je ne sais pas quel impact ça peut avoir en terme d'outillage automatisé, donc je me suis décidé à corriger ça en ajoutant un check.

Par ailleurs, je corrige les liens morts une fois que le test a bien prouvé son efficacité.

NOTE: je n'ai volontairement pas été traiter les liens morts éventuellement présents dans le readme, mais on pourra étendre le script à cela plus tard.

### Liens morts détectés et corrigés

```elixir
%{status: 404, url: "https://github.com/etalab/schema-irve/raw/v2.2.1/schema.json"}
%{status: 404, url: "https://github.com/etalab/schema-irve/raw/v2.2.1/exemple-valide-dynamique.csv"}
%{status: 404, url: "https://github.com/etalab/schema-irve/raw/v2.2.1/exemple-valide.csv"}
```