### PR TITLE
Changement email de contact

### DIFF
--- a/statique/README.md
+++ b/statique/README.md
@@ -57,5 +57,5 @@ En cas de non consolidation de vos données, la raison principale possible est q
 
 * [Fichier gabarit à télécharger au format csv](https://www.data.gouv.fr/fr/datasets/fichier-exemple-stations-de-recharge-de-vehicules-electriques/) (proposé par Etalab)
 * Pour poser une question, commenter, faire un retour d’usage ou contribuer à l’amélioration du modèle de données, vous pouvez :
-  * adresser un message à [contact@transport.beta.gouv.fr](mailto:contact@transport.beta.gouv.fr)
+  * adresser un message à [contact@transport.data.gouv.fr](mailto:contact@transport.data.gouv.fr)
   * ouvrir un ticket sur le [dépôt GitHub du schéma](https://github.com/etalab/schema-irve/issues/new)


### PR DESCRIPTION
L’email était encore en `@transport.beta.gouv.fr` alors qu’il s’agit à présent de `@transport.data.gouv.fr`
